### PR TITLE
[#30] Добавить работу с несколькими файлами

### DIFF
--- a/core/src/commonMain/kotlin/ru/hopec/core/CompilationContext.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/CompilationContext.kt
@@ -2,17 +2,14 @@ package ru.hopec.core
 
 import ru.hopec.core.tree.GenericTree
 
-class CompilationContext {
-    private val trees: MutableList<GenericTree> = mutableListOf()
-    private val status: MultiStatus = MultiStatus(label = "Compilation")
+interface CompilationContext {
+    fun trees(): List<TranslationUnitRepresentations>
 
-    fun rememberTree(tree: GenericTree) {
-        trees.add(tree)
-    }
+    fun rememberTree(tree: GenericTree)
 
-    fun trees(): List<GenericTree> = trees
+    fun report(status: CompilationStatus)
 
-    fun report(status: CompilationStatus): Any = this.status.add(status)
+    fun result(): CompilationStatus
 
-    fun result(): CompilationStatus = status
+    fun resolveModule(module: String): TranslationUnit?
 }

--- a/core/src/commonMain/kotlin/ru/hopec/core/GlobalCompilationContext.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/GlobalCompilationContext.kt
@@ -1,0 +1,35 @@
+package ru.hopec.core
+
+import ru.hopec.core.topography.Resource
+import ru.hopec.core.tree.GenericTree
+
+class GlobalCompilationContext(
+    private val status: MultiStatus = MultiStatus(label = "Compilation"),
+    private val units: TranslationUnits = TranslationUnits(),
+) : CompilationContext {
+    override fun trees() = units.all().flatMap { it.context.trees() }
+
+    override fun rememberTree(tree: GenericTree) {}
+
+    override fun report(status: CompilationStatus) = this.status.add(status)
+
+    override fun result(): CompilationStatus = status
+
+    override fun resolveModule(module: String) = units.resolve(module)
+
+    fun resolveMain() = units.resolveMain()
+
+    fun newTranslationUnit(
+        resource: Resource,
+        vararg initial: Representation,
+    ) {
+        val local = MultiStatus(label = "Compilation of module ${resource.moduleName()}")
+        report(local)
+        units.add(TranslationUnit(localContext(resource, local), resource, initial.toMutableList()))
+    }
+
+    private fun localContext(
+        resource: Resource,
+        status: MultiStatus,
+    ): LocalCompilationContext = LocalCompilationContext(this, resource, mutableListOf(), status)
+}

--- a/core/src/commonMain/kotlin/ru/hopec/core/LocalCompilationContext.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/LocalCompilationContext.kt
@@ -1,0 +1,29 @@
+package ru.hopec.core
+
+import ru.hopec.core.topography.Resource
+import ru.hopec.core.tree.GenericTree
+import ru.hopec.core.tree.intoNode
+import ru.hopec.core.tree.statusTreeType
+
+class LocalCompilationContext(
+    private val global: CompilationContext,
+    private val resource: Resource,
+    private val trees: MutableList<GenericTree>,
+    private val status: MultiStatus,
+) : CompilationContext {
+    override fun trees(): List<TranslationUnitRepresentations> {
+        val trees = this.trees.toMutableList()
+        trees.add(GenericTree(statusTreeType(), status.intoNode()))
+        return listOf(TranslationUnitRepresentations(resource, trees.toList()))
+    }
+
+    override fun rememberTree(tree: GenericTree) {
+        trees.add(tree)
+    }
+
+    override fun report(status: CompilationStatus) = this.status.add(status)
+
+    override fun result(): CompilationStatus = status
+
+    override fun resolveModule(module: String) = global.resolveModule(module)
+}

--- a/core/src/commonMain/kotlin/ru/hopec/core/TranslationUnit.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/TranslationUnit.kt
@@ -1,0 +1,31 @@
+package ru.hopec.core
+
+import ru.hopec.core.topography.Point
+import ru.hopec.core.topography.Range
+import ru.hopec.core.topography.Resource
+
+data class TranslationUnit(
+    val context: CompilationContext,
+    val resource: Resource,
+    val representations: MutableList<Representation>,
+) {
+    fun isMain() = moduleName() == mainModuleName()
+
+    fun moduleName() = resource.moduleName()
+
+    fun range(
+        from: Point?,
+        to: Point?,
+    ) = Range(resource, from, to)
+
+    inline fun <reified F : Representation, T : Representation> runPass(pass: CompilationPass<F, T>): T? {
+        val from = representation<F>() ?: return null
+        val result = pass.run(from, context) ?: return null
+        representations.add(result)
+        return result
+    }
+
+    inline fun <reified T> representation() = representations.filterIsInstance<T>().firstOrNull()
+}
+
+fun mainModuleName() = "main"

--- a/core/src/commonMain/kotlin/ru/hopec/core/TranslationUnitRepresentations.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/TranslationUnitRepresentations.kt
@@ -1,0 +1,9 @@
+package ru.hopec.core
+
+import ru.hopec.core.topography.Resource
+import ru.hopec.core.tree.GenericTree
+
+data class TranslationUnitRepresentations(
+    val resource: Resource,
+    val trees: List<GenericTree>,
+)

--- a/core/src/commonMain/kotlin/ru/hopec/core/TranslationUnits.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/TranslationUnits.kt
@@ -1,0 +1,13 @@
+package ru.hopec.core
+
+class TranslationUnits {
+    private val units: MutableMap<String, TranslationUnit> = mutableMapOf()
+
+    fun add(initial: TranslationUnit) = units.put(initial.resource.moduleName(), initial)
+
+    fun resolve(module: String) = units[module]
+
+    fun resolveMain() = units.values.find { it.isMain() }
+
+    fun all(): List<TranslationUnit> = units.values.toList()
+}

--- a/core/src/commonMain/kotlin/ru/hopec/core/topography/Resource.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/topography/Resource.kt
@@ -2,4 +2,11 @@ package ru.hopec.core.topography
 
 data class Resource(
     val path: String,
-)
+) {
+    fun moduleName(): String =
+        path
+            .split('/')
+            .last()
+            .split('.')
+            .first()
+}

--- a/core/src/commonMain/kotlin/ru/hopec/core/tree/StatusTree.kt
+++ b/core/src/commonMain/kotlin/ru/hopec/core/tree/StatusTree.kt
@@ -13,3 +13,5 @@ fun CompilationStatus.intoNode(): GenericNode =
             listOf()
         },
     )
+
+fun statusTreeType(): String = "STATUS"

--- a/core/src/wasmJsMain/kotlin/ru/hopec/core/ConvertRepresentations.kt
+++ b/core/src/wasmJsMain/kotlin/ru/hopec/core/ConvertRepresentations.kt
@@ -1,0 +1,8 @@
+package ru.hopec.core
+
+@OptIn(ExperimentalWasmJsInterop::class)
+fun TranslationUnitRepresentations.toJsObject() =
+    JsObject().apply {
+        set("resource", resource.toJsObject())
+        set("trees", trees.map { it.toJsObject() }.toJsArray())
+    }

--- a/desugarer/src/commonTest/kotlin/ru/hopec/desugarer/DesugarerTest.kt
+++ b/desugarer/src/commonTest/kotlin/ru/hopec/desugarer/DesugarerTest.kt
@@ -1,18 +1,17 @@
 package ru.hopec.desugarer
 
 import kotlinx.coroutines.test.runTest
-import ru.hopec.core.CompilationContext
+import ru.hopec.core.GlobalCompilationContext
 import ru.hopec.renamer.AstNode
 import ru.hopec.renamer.Program
 import ru.hopec.renamer.RenamedRepresentation
-import kotlin.collections.emptyList
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class DesugarerTest {
     private fun startDesugarer(from: RenamedRepresentation): DesugaredRepresentation? {
-        val context = CompilationContext()
+        val context = GlobalCompilationContext()
         return try {
             DesugarerPass.run(from, context)
         } catch (e: Throwable) {

--- a/driver/src/commonMain/kotlin/ru/hopec/driver/Hopec.kt
+++ b/driver/src/commonMain/kotlin/ru/hopec/driver/Hopec.kt
@@ -4,9 +4,12 @@ import okio.Buffer
 import okio.Sink
 import ru.hopec.codegen.CodeGenPass
 import ru.hopec.codegen.WasmRepresentation
-import ru.hopec.core.CompilationContext
 import ru.hopec.core.CompilationPass
+import ru.hopec.core.CompilationStatus
+import ru.hopec.core.GlobalCompilationContext
+import ru.hopec.core.errorStatus
 import ru.hopec.core.then
+import ru.hopec.core.topography.Range
 import ru.hopec.desugarer.DesugarerPass
 import ru.hopec.parser.TreeSitterRepresentation
 import ru.hopec.parser.treesitter.TsTree
@@ -16,24 +19,34 @@ import ru.hopec.typecheck.TypeCheckPass
 expect fun compileWatToBinary(wat: String): ByteArray
 
 class Hopec(
-    private val context: CompilationContext,
+    private val context: GlobalCompilationContext,
 ) {
     fun makeChain(): CompilationPass<TreeSitterRepresentation, WasmRepresentation> =
         RenamerPass.then(DesugarerPass).then(TypeCheckPass()).then(CodeGenPass())
 
     fun run(
-        input: TsTree,
+        tree: TsTree,
         output: Sink,
-    ): Int {
+    ): CompilationStatus = run(HopecInput(tree), output)
+
+    fun run(
+        input: HopecInput,
+        output: Sink,
+    ): CompilationStatus {
+        input.populate(context)
         val watCode =
             try {
-                makeChain().run(TreeSitterRepresentation(input), context)?.wat
+                (context.resolveMain() ?: return noMain()).runPass(makeChain())?.wat
             } catch (_: NotImplementedError) {
                 null
-            } ?: return 1
+            } ?: return notImplemented()
 
         val wasmBinary = compileWatToBinary(watCode)
         output.write(Buffer().write(wasmBinary), wasmBinary.size.toLong())
-        return 0
+        return context.result()
     }
+
+    private fun noMain(): CompilationStatus = errorStatus("No main module present", Range())
+
+    private fun notImplemented(): CompilationStatus = errorStatus("There are unimplemented parts of pipeline", Range())
 }

--- a/driver/src/commonMain/kotlin/ru/hopec/driver/HopecInput.kt
+++ b/driver/src/commonMain/kotlin/ru/hopec/driver/HopecInput.kt
@@ -1,0 +1,16 @@
+package ru.hopec.driver
+
+import ru.hopec.core.GlobalCompilationContext
+import ru.hopec.core.mainModuleName
+import ru.hopec.core.topography.Resource
+import ru.hopec.parser.TreeSitterRepresentation
+import ru.hopec.parser.treesitter.TsTree
+
+class HopecInput(
+    val resources: List<Pair<Resource, TsTree>>,
+) {
+    constructor(tree: TsTree) : this(listOf(Resource(mainModuleName()) to tree))
+
+    fun populate(context: GlobalCompilationContext) =
+        resources.forEach { context.newTranslationUnit(it.first, TreeSitterRepresentation(it.second)) }
+}

--- a/driver/src/jvmMain/kotlin/ru/hopec/driver/HopecCli.kt
+++ b/driver/src/jvmMain/kotlin/ru/hopec/driver/HopecCli.kt
@@ -8,7 +8,8 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.types.path
 import kotlinx.coroutines.runBlocking
 import okio.Buffer
-import ru.hopec.core.CompilationContext
+import ru.hopec.core.GlobalCompilationContext
+import ru.hopec.core.isError
 import ru.hopec.parser.treesitter.parseHope
 import java.nio.file.Path
 import kotlin.io.path.readText
@@ -19,8 +20,8 @@ class HopecCompile : CliktCommand() {
     override fun run() {
         val tree = runBlocking { parseHope(input.readText()) }
         val buffer = Buffer()
-        val status = Hopec(CompilationContext()).run(tree, buffer)
-        if (status != 0) {
+        val status = Hopec(GlobalCompilationContext()).run(tree, buffer)
+        if (status.isError()) {
             echo("compilation failed", err = true)
             return
         }

--- a/driver/src/jvmTest/kotlin/ru/hopec/driver/test/EndToEndTest.kt
+++ b/driver/src/jvmTest/kotlin/ru/hopec/driver/test/EndToEndTest.kt
@@ -4,7 +4,8 @@ import com.dylibso.chicory.runtime.Instance
 import com.dylibso.chicory.wasm.Parser
 import kotlinx.coroutines.runBlocking
 import okio.Buffer
-import ru.hopec.core.CompilationContext
+import ru.hopec.core.GlobalCompilationContext
+import ru.hopec.core.isError
 import ru.hopec.driver.Hopec
 import ru.hopec.parser.treesitter.parseHope
 import kotlin.test.Test
@@ -15,8 +16,8 @@ class EndToEndTest {
     private fun compile(source: String): ByteArray? {
         val tree = runBlocking { parseHope(source) }
         val buffer = Buffer()
-        val status = Hopec(CompilationContext()).run(tree, buffer)
-        if (status != 0) return null
+        val status = Hopec(GlobalCompilationContext()).run(tree, buffer)
+        if (status.isError()) return null
         return buffer.readByteArray()
     }
 

--- a/driver/src/wasmJsMain/kotlin/ru/hopec/driver/CompilationInput.kt
+++ b/driver/src/wasmJsMain/kotlin/ru/hopec/driver/CompilationInput.kt
@@ -1,0 +1,25 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package ru.hopec.driver
+
+import ru.hopec.parser.treesitter.JsTree
+import ru.hopec.parser.treesitter.Tree
+
+external interface Resource {
+    val path: String
+}
+
+fun Resource.toHopec() =
+    ru.hopec.core.topography
+        .Resource(path)
+
+external interface TranslationUnit : JsAny {
+    val resource: Resource
+    val tree: Tree
+}
+
+external interface CompilationInput {
+    val resources: JsArray<TranslationUnit>
+}
+
+fun CompilationInput.toHopec() = HopecInput(resources.toList().map { it.resource.toHopec() to JsTree(it.tree) })

--- a/driver/src/wasmJsMain/kotlin/ru/hopec/driver/CompileTree.kt
+++ b/driver/src/wasmJsMain/kotlin/ru/hopec/driver/CompileTree.kt
@@ -4,24 +4,22 @@ package ru.hopec.driver
 
 import okio.Buffer
 import ru.hopec.core.CompilationContext
+import ru.hopec.core.GlobalCompilationContext
 import ru.hopec.core.JsObject
 import ru.hopec.core.StatusSeverity
+import ru.hopec.core.TranslationUnitRepresentations
 import ru.hopec.core.set
 import ru.hopec.core.toJsObject
-import ru.hopec.core.tree.GenericTree
-import ru.hopec.core.tree.intoNode
-import ru.hopec.parser.treesitter.JsTree
-import ru.hopec.parser.treesitter.Tree
 import kotlin.wasm.unsafe.Pointer
 import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
 import kotlin.wasm.unsafe.withScopedMemoryAllocator
 
 @OptIn(ExperimentalWasmJsInterop::class, UnsafeWasmMemoryApi::class)
 @JsExport
-fun compile(input: Tree): JsObject {
+fun compile(input: CompilationInput): JsObject {
     val buffer = Buffer()
-    val context = CompilationContext()
-    Hopec(context).run(JsTree(input), buffer)
+    val context = GlobalCompilationContext()
+    Hopec(context).run(input.toHopec(), buffer)
     val result = buffer.readByteArray()
     withScopedMemoryAllocator {
         val buffer = Pointer(0U)
@@ -32,9 +30,9 @@ fun compile(input: Tree): JsObject {
 
 data class CompilationResult(
     val size: UInt,
-    val representations: List<GenericTree>,
+    val representations: List<TranslationUnitRepresentations>,
 ) {
-    constructor(size: UInt, context: CompilationContext) : this(size, trees(context))
+    constructor(size: UInt, context: CompilationContext) : this(size, context.trees())
 
     @OptIn(ExperimentalWasmJsInterop::class)
     fun toJsObject() =
@@ -42,11 +40,6 @@ data class CompilationResult(
             set("size", size)
             set("representations", representations.map { it.toJsObject() }.toJsArray())
         }
-}
-
-private fun trees(context: CompilationContext): List<GenericTree> {
-    context.rememberTree(GenericTree(statusTreeType(), context.result().intoNode()))
-    return context.trees()
 }
 
 @JsExport

--- a/hope-web/src/lib/components/Editor.svelte
+++ b/hope-web/src/lib/components/Editor.svelte
@@ -34,7 +34,7 @@
 	let project: ImaginaryProject = $state(loadProject(examplarProject()));
 	let opened: ImaginaryFile | undefined = $state();
 	let parsed: ParsedProject | undefined = $state();
-	let trees: SvelteMap<Resource, SvelteMap<string, GenericTree>> = new SvelteMap();
+	let trees: SvelteMap<string, SvelteMap<string, GenericTree>> = new SvelteMap();
 
 	onMount(async () => {
 		await initEditor();
@@ -54,8 +54,11 @@
 	}
 
 	function updateTree(t: Tree) {
-		setTree(new TsToTree(t, opened?.currentResource()).build());
-		rebuild();
+		const resource = opened?.currentResource();
+		if (resource) {
+			setTree(resource, new TsToTree(t, resource).build());
+			rebuild();
+		}
 	}
 
 	function currentTrees(): SvelteMap<string, GenericTree> {
@@ -63,7 +66,7 @@
 		if (!resource) {
 			return new SvelteMap();
 		}
-		return trees.get(resource) ?? new SvelteMap();
+		return trees.get(resource.path) ?? new SvelteMap();
 	}
 
 	function rebuild() {
@@ -77,9 +80,7 @@
 	}
 
 	function setTrees(representations: TranslationUnitRepresentations[]) {
-		representations.forEach((repr) =>
-			repr.trees.forEach((tree) => setTreeInResource(repr.resource, tree))
-		);
+		representations.forEach((repr) => repr.trees.forEach((tree) => setTree(repr.resource, tree)));
 	}
 
 	function updateMarkers(problems: CompilationStatus[]) {
@@ -88,32 +89,29 @@
 		);
 	}
 
-	function setTree(tree: GenericTree | undefined) {
-		const resource = tree?.root.range.resource;
-		if (!resource) {
-			return;
+	function setTree(resource: Resource, tree: GenericTree) {
+		if (!trees.has(resource.path)) {
+			trees.set(resource.path, new SvelteMap());
 		}
-		setTreeInResource(resource, tree);
-	}
-
-	function setTreeInResource(resource: Resource, tree: GenericTree) {
-		if (!trees.has(resource)) {
-			trees.set(resource, new SvelteMap());
-		}
-		trees.get(resource)!.set(tree.type, tree);
+		trees.get(resource.path)!.set(tree.type, tree);
 	}
 
 	function open(file: ImaginaryFile) {
-		opened?.encode(editor?.currentContents() ?? '');
+		closeFile();
 		opened = file;
 		value = file.decode();
 		editor?.installContent(value);
 		bindParsedFile();
 	}
 
+	function closeFile() {
+		parsed?.currentFile()?.unbind();
+		opened?.encode(editor?.currentContents() ?? '');
+	}
+
 	function bindParsedFile() {
-		parsed?.currentFile()?.bind();
 		parsed?.currentFile()?.listenTree({ notify: updateTree });
+		parsed?.currentFile()?.bind();
 	}
 
 	function rebuildFileTree() {

--- a/hope-web/src/lib/components/Editor.svelte
+++ b/hope-web/src/lib/components/Editor.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import { MonacoEditor } from '$lib/entities/editor.svelte';
-	import { Highlighting } from '$lib/entities/highlighting.svelte';
-	import { TreeSitter } from '$lib/entities/parser.svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import type { Tree } from 'web-tree-sitter';
 	import Appearance from './Appearance.svelte';
@@ -19,34 +17,34 @@
 		type RenderedResourceRow
 	} from '$lib/entities/fs/rendered_resource.svelte';
 	import FileTree from './fs/FileTree.svelte';
-	import { Compiler } from '$lib/entities/compiler.svelte';
+	import { Compiler, type CompilationStatus } from '$lib/entities/compiler.svelte';
 	import { TsToTree } from '$lib/entities/tree/tree_sitter';
 	import { SvelteMap } from 'svelte/reactivity';
-	import type { GenericTree, Range } from '$lib/entities/tree/generic_tree';
+	import type { GenericTree, Range, Resource } from '$lib/entities/tree/generic_tree';
 	import TreesView from './TreesView.svelte';
+	import { ParsedProject } from '$lib/entities/parsed_project.svelte';
+	import type { TranslationUnitRepresentations } from '$lib/entities/hopec';
 
 	let { editor = $bindable() }: { editor: MonacoEditor | undefined } = $props();
 	let value: string = $state('');
 	let view: HTMLDivElement | undefined = $state();
 	let compiler = new Compiler();
-	let highlight: Highlighting | undefined = $state();
-	let sitter = new TreeSitter();
 	let terminal = new Terminal();
 	let files: RenderedResourceRow[] = $state([]);
 	let project: ImaginaryProject = $state(loadProject(examplarProject()));
 	let opened: ImaginaryFile | undefined = $state();
-	let trees: SvelteMap<string, GenericTree> = new SvelteMap();
+	let parsed: ParsedProject | undefined = $state();
+	let trees: SvelteMap<Resource, SvelteMap<string, GenericTree>> = new SvelteMap();
 
 	onMount(async () => {
 		await initEditor();
-		await sitter.init(() => editor!.currentContents());
-		await initHighlighting();
+		parsed = new ParsedProject(editor!, () => opened);
+		parsed.openProject(project);
 		rebuildFileTree();
 	});
 
 	onDestroy(() => {
-		highlight?.dispose();
-		sitter.dispose();
+		parsed?.closeProject();
 		editor?.dispose();
 	});
 
@@ -55,29 +53,54 @@
 		await editor.init();
 	}
 
-	async function initHighlighting() {
-		highlight = new Highlighting(editor!, sitter);
-		highlight.listenTree({ notify: updateTree });
-		await highlight.init();
-	}
-
 	function updateTree(t: Tree) {
-		setTree(new TsToTree(t, undefined).build());
-		compiler.rebuild(t);
+		setTree(new TsToTree(t, opened?.currentResource()).build());
+		rebuild();
 	}
 
-	$effect(() => {
-		setTree(compiler.statusTree());
-		editor?.updateMarkers(
-			compiler.currentProblems()
-			// .filter((problem) => problem.resource?.path === opened?.currentPath())
+	function currentTrees(): SvelteMap<string, GenericTree> {
+		const resource = opened?.currentResource();
+		if (!resource) {
+			return new SvelteMap();
+		}
+		return trees.get(resource) ?? new SvelteMap();
+	}
+
+	function rebuild() {
+		const input = parsed?.buildInput();
+		if (!input) {
+			return;
+		}
+		compiler.rebuild(input);
+		setTrees(compiler.currentRepresentations());
+		updateMarkers(compiler.currentProblems());
+	}
+
+	function setTrees(representations: TranslationUnitRepresentations[]) {
+		representations.forEach((repr) =>
+			repr.trees.forEach((tree) => setTreeInResource(repr.resource, tree))
 		);
-	});
+	}
+
+	function updateMarkers(problems: CompilationStatus[]) {
+		editor?.updateMarkers(
+			problems.filter((problem) => problem.resource?.path === opened?.currentPath())
+		);
+	}
 
 	function setTree(tree: GenericTree | undefined) {
-		if (tree) {
-			trees.set(tree.type, tree);
+		const resource = tree?.root.range.resource;
+		if (!resource) {
+			return;
 		}
+		setTreeInResource(resource, tree);
+	}
+
+	function setTreeInResource(resource: Resource, tree: GenericTree) {
+		if (!trees.has(resource)) {
+			trees.set(resource, new SvelteMap());
+		}
+		trees.get(resource)!.set(tree.type, tree);
 	}
 
 	function open(file: ImaginaryFile) {
@@ -85,6 +108,12 @@
 		opened = file;
 		value = file.decode();
 		editor?.installContent(value);
+		bindParsedFile();
+	}
+
+	function bindParsedFile() {
+		parsed?.currentFile()?.bind();
+		parsed?.currentFile()?.listenTree({ notify: updateTree });
 	}
 
 	function rebuildFileTree() {
@@ -99,7 +128,7 @@
 <div class="flex h-screen flex-col">
 	<div class="flex flex-row">
 		<Appearance />
-		<Run freshTree={() => sitter.freshParse()} {terminal} />
+		<Run input={() => parsed?.buildInput()} {terminal} />
 	</div>
 	<div class="flex flex-1 flex-row overflow-auto">
 		<FileTree rows={files} {open} rebuild={rebuildFileTree} />
@@ -108,7 +137,7 @@
 			<TerminalComponent {terminal} />
 		</div>
 		<div class="flex flex-2 flex-col overflow-auto p-1">
-			<TreesView {trees} {focus} />
+			<TreesView trees={currentTrees()} {focus} />
 		</div>
 	</div>
 </div>

--- a/hope-web/src/lib/components/Run.svelte
+++ b/hope-web/src/lib/components/Run.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
 	import { Compiler } from '$lib/entities/compiler.svelte';
+	import type { CompilationInput } from '$lib/entities/hopec';
 	import type { Terminal } from '$lib/entities/terminal.svelte';
-	import type { Tree } from 'web-tree-sitter';
 
 	let compiler = new Compiler();
-	let { freshTree, terminal }: { freshTree: () => Tree | undefined; terminal: Terminal } = $props();
+	let { input, terminal }: { input: () => CompilationInput | undefined; terminal: Terminal } =
+		$props();
 
 	async function run(): Promise<void> {
-		const tree = freshTree();
-		if (!tree) {
+		const trees = input();
+		if (!trees) {
 			terminal.writeln('No syntax tree to compile');
 			return;
 		}
 		compiler.currentProblems().forEach((problem) => terminal.writeln(problem.message));
-		const compiled = await compiler.compile(tree);
+		const compiled = await compiler.compile(trees);
 		if (!compiled) {
 			terminal.writeln('Compilation failed');
 			return;

--- a/hope-web/src/lib/entities/compiler.svelte.ts
+++ b/hope-web/src/lib/entities/compiler.svelte.ts
@@ -84,7 +84,6 @@ export class Compiler {
 function debounced(callback: (input: CompilationInput) => void) {
 	let timeout: number;
 	return (input: CompilationInput) => {
-    console.log(input);
 		window.clearTimeout(timeout);
 		timeout = window.setTimeout(() => callback(input), 300);
 	};

--- a/hope-web/src/lib/entities/compiler.svelte.ts
+++ b/hope-web/src/lib/entities/compiler.svelte.ts
@@ -1,12 +1,17 @@
-import type { Tree } from 'web-tree-sitter';
 import {
 	allLeaves,
 	zeroPoint,
 	type GenericNode,
+	type GenericTree,
 	type Point,
 	type Resource
 } from './tree/generic_tree';
-import { Hopec, type CompilationResult } from './hopec';
+import {
+	Hopec,
+	type CompilationInput,
+	type CompilationResult,
+	type TranslationUnitRepresentations
+} from './hopec';
 
 export type StatusSeverity = 'info' | 'warning' | 'error';
 
@@ -20,7 +25,7 @@ export interface CompilationStatus {
 
 export class Compiler {
 	private readonly hopec: Hopec;
-	readonly rebuild: (input: Tree) => void;
+	readonly rebuild: (input: CompilationInput) => void;
 	private result: CompilationResult | undefined;
 
 	constructor() {
@@ -29,7 +34,7 @@ export class Compiler {
 		this.result = $state();
 	}
 
-	async compile(input: Tree): Promise<WebAssembly.Instance | undefined> {
+	async compile(input: CompilationInput): Promise<WebAssembly.Instance | undefined> {
 		const result = this.hopec.compile(input);
 		this.result = result;
 		if (!result || result.size === 0) {
@@ -39,15 +44,18 @@ export class Compiler {
 	}
 
 	currentProblems(): CompilationStatus[] {
-		const tree = this.statusTree();
-		if (!tree) {
-			return [];
-		}
-		return allLeaves(tree).map((problem) => this.status(problem));
+		return this.statusTrees().flatMap(allLeaves).map(this.status.bind(this));
 	}
 
-	statusTree() {
-		return this.result?.representations.find((tree) => tree.type === this.hopec.statusTreeType());
+	private statusTrees(): GenericTree[] {
+		return this.currentRepresentations()
+			.map((repr) => repr.trees.find((tree) => tree.type === this.hopec.statusTreeType()))
+			.filter((tree) => tree)
+			.map((tree) => tree!);
+	}
+
+	currentRepresentations(): TranslationUnitRepresentations[] {
+		return this.result?.representations ?? [];
 	}
 
 	private status(problem: GenericNode): CompilationStatus {
@@ -73,9 +81,10 @@ export class Compiler {
 	}
 }
 
-function debounced(callback: (input: Tree) => void) {
+function debounced(callback: (input: CompilationInput) => void) {
 	let timeout: number;
-	return (input: Tree) => {
+	return (input: CompilationInput) => {
+    console.log(input);
 		window.clearTimeout(timeout);
 		timeout = window.setTimeout(() => callback(input), 300);
 	};

--- a/hope-web/src/lib/entities/editor.svelte.ts
+++ b/hope-web/src/lib/entities/editor.svelte.ts
@@ -47,6 +47,13 @@ export class MonacoEditor {
 		this.listeners.content.push(listener);
 	}
 
+	removeEditListener(listener: (e: editor.IModelContentChangedEvent) => void) {
+		const index = this.listeners.content.indexOf(listener);
+		if (index != -1) {
+			this.listeners.content.splice(index, 1);
+		}
+	}
+
 	onContentChange(e: editor.IModelContentChangedEvent) {
 		this.listeners.content.forEach((listener) => listener(e));
 	}

--- a/hope-web/src/lib/entities/fs/file.svelte.ts
+++ b/hope-web/src/lib/entities/fs/file.svelte.ts
@@ -1,3 +1,4 @@
+import type { Resource } from '../tree/generic_tree';
 import { type ImaginaryContainer } from './resource.svelte';
 
 export class ImaginaryFile {
@@ -50,5 +51,13 @@ export class ImaginaryFile {
 			name: this.name,
 			contents: btoa(Array.from(this.contents, (byte) => String.fromCodePoint(byte)).join(''))
 		};
+	}
+
+	allFiles() {
+		return [this];
+	}
+
+	currentResource(): Resource {
+		return { path: this.currentPath() };
 	}
 }

--- a/hope-web/src/lib/entities/fs/folder.svelte.ts
+++ b/hope-web/src/lib/entities/fs/folder.svelte.ts
@@ -71,4 +71,8 @@ export class ImaginaryFolder {
 			children: this.sortedChildren().map((child) => child.serialize())
 		};
 	}
+
+	allFiles() {
+		return this.children.flatMap((child) => child.allFiles());
+	}
 }

--- a/hope-web/src/lib/entities/fs/project.svelte.ts
+++ b/hope-web/src/lib/entities/fs/project.svelte.ts
@@ -64,4 +64,8 @@ export class ImaginaryProject {
 			root: this.root.serialize()
 		};
 	}
+
+	allFiles() {
+		return this.root.allFiles();
+	}
 }

--- a/hope-web/src/lib/entities/fs/resource.svelte.ts
+++ b/hope-web/src/lib/entities/fs/resource.svelte.ts
@@ -1,4 +1,4 @@
-import type { ImaginaryFile } from "./file.svelte";
+import type { ImaginaryFile } from './file.svelte';
 
 export interface ImaginaryResource {
 	currentParent(): ImaginaryContainer | undefined;
@@ -15,7 +15,7 @@ export interface ImaginaryResource {
 
 	serialize(): object;
 
-  allFiles(): ImaginaryFile[];
+	allFiles(): ImaginaryFile[];
 }
 
 export interface ImaginaryContainer extends ImaginaryResource {

--- a/hope-web/src/lib/entities/fs/resource.svelte.ts
+++ b/hope-web/src/lib/entities/fs/resource.svelte.ts
@@ -1,3 +1,5 @@
+import type { ImaginaryFile } from "./file.svelte";
+
 export interface ImaginaryResource {
 	currentParent(): ImaginaryContainer | undefined;
 
@@ -12,6 +14,8 @@ export interface ImaginaryResource {
 	isContainer(): boolean;
 
 	serialize(): object;
+
+  allFiles(): ImaginaryFile[];
 }
 
 export interface ImaginaryContainer extends ImaginaryResource {

--- a/hope-web/src/lib/entities/highlighting.svelte.ts
+++ b/hope-web/src/lib/entities/highlighting.svelte.ts
@@ -10,25 +10,31 @@ export interface HighlightingListener {
 
 export class Highlighting {
 	private readonly listeners: HighlightingListener[];
+	private readonly listener: (e: editor.IModelContentChangedEvent) => void;
 
 	constructor(
 		private readonly editor: MonacoEditor,
 		private readonly parser: TreeSitter
 	) {
 		this.listeners = [];
+		this.listener = this.edited.bind(this);
 	}
 
 	listenTree(listener: HighlightingListener) {
 		this.listeners.push(listener);
 	}
 
-	async init(): Promise<void> {
-		this.parser.parse();
-		this.editor.addEditListener((e) => this.edited(e));
+	bind() {
+		this.editor.addEditListener(this.listener);
 		const tree = this.parser.currentTree();
 		if (tree) {
 			this.highlight(tree.rootNode);
+			this.fireTreeUpdated();
 		}
+	}
+
+	unbind() {
+		this.editor.removeEditListener(this.listener);
 	}
 
 	private edited(e: editor.IModelContentChangedEvent) {
@@ -67,7 +73,7 @@ export class Highlighting {
 		return { row: line - 1, column: column - 1 };
 	}
 
-	highlight(node: Node) {
+	private highlight(node: Node) {
 		const decorations: editor.IModelDeltaDecoration[] = [];
 		this.parser.highlightingInfo(node.tree.rootNode).forEach((highlighted) =>
 			decorations.push({
@@ -81,7 +87,6 @@ export class Highlighting {
 			})
 		);
 		this.editor.updateDecorations(decorations);
-		this.fireTreeUpdated();
 	}
 
 	private fireTreeUpdated() {
@@ -89,9 +94,5 @@ export class Highlighting {
 		if (tree) {
 			this.listeners.forEach((l) => l.notify(tree));
 		}
-	}
-
-	dispose() {
-		this.parser.dispose();
 	}
 }

--- a/hope-web/src/lib/entities/hopec.ts
+++ b/hope-web/src/lib/entities/hopec.ts
@@ -1,11 +1,25 @@
 import type { Tree } from 'web-tree-sitter';
 import * as hopec from 'hopec-driver';
-import type { GenericTree } from './tree/generic_tree';
+import type { GenericTree, Resource } from './tree/generic_tree';
+
+export interface TranslationUnitRepresentations {
+  resource: Resource;
+	trees: GenericTree[];
+}
 
 export interface CompilationResult {
 	size: number;
-	representations: GenericTree[];
+	representations: TranslationUnitRepresentations[];
 	instance: WebAssembly.Instance;
+}
+
+export interface TranslationUnit {
+  resource: Resource;
+	tree: Tree;
+}
+
+export interface CompilationInput {
+	resources: TranslationUnit[];
 }
 
 const memory = initializeMemory();
@@ -17,8 +31,8 @@ function initializeMemory(): WebAssembly.Memory {
 }
 
 export class Hopec {
-	compile(input: Tree): CompilationResult | undefined {
-		return (hopec.compile as (input: Tree) => CompilationResult | undefined)(input);
+	compile(input: CompilationInput): CompilationResult | undefined {
+		return (hopec.compile as (input: CompilationInput) => CompilationResult | undefined)(input);
 	}
 
 	statusTreeType(): string {

--- a/hope-web/src/lib/entities/hopec.ts
+++ b/hope-web/src/lib/entities/hopec.ts
@@ -3,7 +3,7 @@ import * as hopec from 'hopec-driver';
 import type { GenericTree, Resource } from './tree/generic_tree';
 
 export interface TranslationUnitRepresentations {
-  resource: Resource;
+	resource: Resource;
 	trees: GenericTree[];
 }
 
@@ -14,7 +14,7 @@ export interface CompilationResult {
 }
 
 export interface TranslationUnit {
-  resource: Resource;
+	resource: Resource;
 	tree: Tree;
 }
 

--- a/hope-web/src/lib/entities/parsed_file.svelte.ts
+++ b/hope-web/src/lib/entities/parsed_file.svelte.ts
@@ -1,0 +1,39 @@
+import { TreeSitter } from './parser.svelte';
+import { Highlighting, type HighlightingListener } from './highlighting.svelte';
+import type { MonacoEditor } from './editor.svelte';
+import type { Tree } from 'web-tree-sitter';
+
+export class ParsedFile {
+	private readonly sitter: TreeSitter;
+	private readonly highlight: Highlighting;
+
+	constructor(editor: MonacoEditor, text: () => string) {
+		this.sitter = new TreeSitter(text);
+		this.highlight = new Highlighting(editor, this.sitter);
+	}
+
+	init() {
+		this.sitter.parse();
+	}
+
+	bind() {
+		this.highlight.bind();
+	}
+
+	unbind() {
+		this.highlight.unbind();
+	}
+
+	listenTree(listener: HighlightingListener) {
+		this.highlight.listenTree(listener);
+	}
+
+	currentTree(): Tree | undefined {
+		return this.sitter.currentTree();
+	}
+
+	dispose() {
+		this.highlight.unbind();
+		this.sitter.dispose();
+	}
+}

--- a/hope-web/src/lib/entities/parsed_file.svelte.ts
+++ b/hope-web/src/lib/entities/parsed_file.svelte.ts
@@ -12,11 +12,8 @@ export class ParsedFile {
 		this.highlight = new Highlighting(editor, this.sitter);
 	}
 
-	init() {
-		this.sitter.parse();
-	}
-
 	bind() {
+		this.sitter.parse();
 		this.highlight.bind();
 	}
 

--- a/hope-web/src/lib/entities/parsed_project.svelte.ts
+++ b/hope-web/src/lib/entities/parsed_project.svelte.ts
@@ -1,0 +1,73 @@
+import { SvelteMap } from 'svelte/reactivity';
+import type { CompilationInput, TranslationUnit } from './hopec';
+import { ParsedFile } from './parsed_file.svelte';
+import type { ImaginaryFile } from './fs/file.svelte';
+import type { MonacoEditor } from './editor.svelte';
+import type { ImaginaryProject } from './fs/project.svelte';
+
+export class ParsedProject {
+	private readonly resources: SvelteMap<ImaginaryFile, ParsedFile> = new SvelteMap();
+
+	constructor(
+		private readonly editor: MonacoEditor,
+		private readonly opened: () => ImaginaryFile | undefined
+	) {}
+
+	createFile(file: ImaginaryFile) {
+		const fresh = new ParsedFile(this.editor, this.currentText(file));
+		fresh.init();
+		this.resources.set(file, fresh);
+	}
+
+	openProject(project: ImaginaryProject) {
+		this.closeProject();
+		project.allFiles().forEach((file) => this.createFile(file));
+	}
+
+	closeProject() {
+		this.resources
+			.keys()
+			.toArray()
+			.forEach((file) => this.deleteFile(file));
+	}
+
+	private currentText(file: ImaginaryFile) {
+		return () => {
+			if (this.opened() == file) {
+				return this.editor.currentContents();
+			}
+			return file.decode();
+		};
+	}
+
+	currentFile(): ParsedFile | undefined {
+		if (!this.opened()) {
+			return undefined;
+		}
+		return this.resources.get(this.opened()!);
+	}
+
+	deleteFile(file: ImaginaryFile) {
+		this.resources.get(file)?.dispose();
+		this.resources.delete(file);
+	}
+
+	buildInput(): CompilationInput {
+		return {
+			resources: this.resources
+				.entries()
+				.map(([file, parsed]) => this.translationUnit(file, parsed))
+				.filter((unit) => unit)
+				.map((unit) => unit!)
+				.toArray()
+		};
+	}
+
+	private translationUnit(file: ImaginaryFile, parsed: ParsedFile): TranslationUnit | undefined {
+		const tree = parsed.currentTree();
+		if (!tree) {
+			return undefined;
+		}
+		return { resource: file.currentResource(), tree: tree };
+	}
+}

--- a/hope-web/src/lib/entities/parsed_project.svelte.ts
+++ b/hope-web/src/lib/entities/parsed_project.svelte.ts
@@ -14,9 +14,7 @@ export class ParsedProject {
 	) {}
 
 	createFile(file: ImaginaryFile) {
-		const fresh = new ParsedFile(this.editor, this.currentText(file));
-		fresh.init();
-		this.resources.set(file, fresh);
+		this.resources.set(file, new ParsedFile(this.editor, this.currentText(file)));
 	}
 
 	openProject(project: ImaginaryProject) {

--- a/hope-web/src/lib/entities/parser.svelte.ts
+++ b/hope-web/src/lib/entities/parser.svelte.ts
@@ -4,8 +4,8 @@ import { HighlightInfo, type Highlighted } from './highlight_info.svelte';
 const hope = await initHope();
 
 async function initHope(): Promise<Language> {
-		await Parser.init();
-		return await Language.load('$lib/../../tree-sitter-hope.wasm');
+	await Parser.init();
+	return await Language.load('$lib/../../tree-sitter-hope.wasm');
 }
 
 export class TreeSitter {

--- a/hope-web/src/lib/entities/parser.svelte.ts
+++ b/hope-web/src/lib/entities/parser.svelte.ts
@@ -1,24 +1,27 @@
 import { Parser, Language, Tree, Edit, type Range, Node } from 'web-tree-sitter';
 import { HighlightInfo, type Highlighted } from './highlight_info.svelte';
 
+const hope = await initHope();
+
+async function initHope(): Promise<Language> {
+		await Parser.init();
+		return await Language.load('$lib/../../tree-sitter-hope.wasm');
+}
+
 export class TreeSitter {
 	private parser: Parser | undefined;
 	private tree: Tree | undefined;
-	private text: (() => string) | undefined;
-	private version: number = 0;
+	private readonly text: () => string | undefined;
 
-	async init(text: () => string): Promise<void> {
-		await Parser.init();
-		const hope = await Language.load('$lib/../../tree-sitter-hope.wasm');
+	constructor(text: () => string | undefined) {
 		this.parser = new Parser();
 		this.parser.setLanguage(hope);
 		this.text = text;
 	}
 
 	parse(): Range[] {
-		this.version++;
 		const old = this.tree;
-		const parsed = this.parser?.parse(this.text!(), old);
+		const parsed = this.parser?.parse(this.text() ?? '', old);
 		if (parsed) {
 			this.tree = parsed!;
 			return old?.getChangedRanges(this.tree) ?? [];
@@ -36,11 +39,7 @@ export class TreeSitter {
 	}
 
 	freshParse(): Tree | undefined {
-		return this.parser?.parse(this.text!(), null) ?? undefined;
-	}
-
-	currentVersion(): number {
-		return this.version;
+		return this.parser?.parse(this.text()!, null) ?? undefined;
 	}
 
 	highlightingInfo(node: Node): Highlighted[] {

--- a/renamer/src/commonTest/kotlin/ru.hopec.parser.test/RenamerTest.kt
+++ b/renamer/src/commonTest/kotlin/ru.hopec.parser.test/RenamerTest.kt
@@ -2,6 +2,7 @@ package ru.hopec.parser.test
 
 import kotlinx.coroutines.test.runTest
 import ru.hopec.core.CompilationContext
+import ru.hopec.core.GlobalCompilationContext
 import ru.hopec.core.StatusSeverity
 import ru.hopec.parser.TreeSitterRepresentation
 import ru.hopec.parser.treesitter.parseHope
@@ -16,13 +17,13 @@ import kotlin.test.assertIs
 
 class RenamerTest {
     private suspend fun contextAfterPass(input: String): CompilationContext {
-        val context = CompilationContext()
+        val context = GlobalCompilationContext()
         runPass(input, context)
         return context
     }
 
     private suspend fun startRenamer(input: String): RenamedRepresentation {
-        val context = CompilationContext()
+        val context = GlobalCompilationContext()
         val result = runPass(input, context) ?: error("renamer failed")
         assertEquals(StatusSeverity.INFO, context.result().severity)
         return result


### PR DESCRIPTION
- теперь на вход компилятора идёт список пар "путь - дерево"
- промежуточные представления сохраняются в `TranslationUnit`
- контекст разделён на глобальный и локальный (локальный соответствует одной единице трансляции)