### PR TITLE
Fix bug

### DIFF
--- a/desugarer/src/commonMain/kotlin/ru/hopec/desugarer/ModuleDesugarer.kt
+++ b/desugarer/src/commonMain/kotlin/ru/hopec/desugarer/ModuleDesugarer.kt
@@ -490,7 +490,7 @@ open class ModuleDesugarer(
             }
 
             is AstNode.VarType -> {
-                Type.Variable(boundVars.size - boundVars.indexOf(type.name))
+                Type.Variable(boundVars.size - boundVars.indexOf(type.name) - 1)
             }
         }
 

--- a/driver/src/jvmTest/kotlin/ru/hopec/driver/test/EndToEndTest.kt
+++ b/driver/src/jvmTest/kotlin/ru/hopec/driver/test/EndToEndTest.kt
@@ -189,6 +189,23 @@ class EndToEndTest {
     }
 
     @Test
+    fun `function signature index notation bug`() {
+        val source =
+            """
+            typevar beta
+            
+            dec badApply : (beta -> beta) # beta -> beta
+            --- badApply(f, acc) <= badApply(f, acc)
+            
+            dec main : num
+            --- main <= 1
+            """.trimIndent()
+        val binary = compile(source) ?: error("compilation failed")
+        assertNotEquals(0, binary.size)
+        Parser.parse(binary)
+    }
+
+    @Test
     fun `compiled module is valid wasm`() {
         val source =
             """


### PR DESCRIPTION
Function types in declarations used to contain typevar indices in one-notation, which caused typechecking failure

Now it contains indices in zero-notation